### PR TITLE
Exposes a BaseURL field on the returned fake service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ do some assertions against.
 ```go
 // Basic Example - you just want your application to be able to hit a fake service
 t.Run("My awesome acceptance test", func(t *testing.T) {
-    downstreamAPI := fakes.NewFakeHTTP("8000")
+    downstreamAPI := fakes.NewFakeHTTP()
     downstreamAPI.AddEndpoint(&fakes.Endpoint{
         Path: "/some/path/my/app/hits",
         Response: `{"status": "great success"}`,
@@ -26,6 +26,8 @@ t.Run("My awesome acceptance test", func(t *testing.T) {
     downstreamAPI.Run(t)
 
     // make a HTTP request to the endpoint that hits our system
+    request, err := http.NewRequest(http.MethodGet, fakeServer.BaseURL, nil)
+    assert.Nil(t, err)
 })
 
 ```

--- a/fakes.go
+++ b/fakes.go
@@ -35,6 +35,8 @@ type FakeService struct {
 	router     *gin.Engine
 	testserver *httptest.Server
 	Endpoints  []*Endpoint
+
+	BaseURL string
 }
 
 func NewFakeHTTP(port string) *FakeService {
@@ -93,6 +95,7 @@ func (f *FakeService) Run(t *testing.T) {
 	}
 	f.testserver.Listener = l
 	f.testserver.Start()
+	f.BaseURL = f.testserver.URL
 	t.Log("Fake Service Successfully Started")
 
 }

--- a/fakes.go
+++ b/fakes.go
@@ -31,7 +31,6 @@ func (e *Endpoint) recordCall() {
 }
 
 type FakeService struct {
-	port       string
 	router     *gin.Engine
 	testserver *httptest.Server
 	Endpoints  []*Endpoint
@@ -39,11 +38,10 @@ type FakeService struct {
 	BaseURL string
 }
 
-func NewFakeHTTP(port string) *FakeService {
+func NewFakeHTTP() *FakeService {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	return &FakeService{
-		port:       port,
 		router:     router,
 		testserver: httptest.NewUnstartedServer(router),
 	}
@@ -74,7 +72,7 @@ func (f *FakeService) AddEndpoint(e *Endpoint) {
 }
 
 func (f *FakeService) TidyUp(t *testing.T) {
-	t.Logf("FakeService tidyup - port:%s", f.port)
+	t.Log("FakeService tidyup...")
 	for _, e := range f.Endpoints {
 		assert.GreaterOrEqual(t, e.calls, 1, "endpoint %s has not been called within this test")
 	}
@@ -82,8 +80,8 @@ func (f *FakeService) TidyUp(t *testing.T) {
 }
 
 func (f *FakeService) Run(t *testing.T) {
-	t.Logf("Fake Service Starting Up on port: %s", f.port)
-	l, err := net.Listen("tcp", fmt.Sprintf(":%s", f.port))
+	t.Log("Fake Service Starting up...")
+	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Errorf("Failed to listen: %s", err.Error())
 		return
@@ -96,6 +94,6 @@ func (f *FakeService) Run(t *testing.T) {
 	f.testserver.Listener = l
 	f.testserver.Start()
 	f.BaseURL = f.testserver.URL
-	t.Log("Fake Service Successfully Started")
+	t.Logf("Fake Service Successfully Started: %s", f.testserver.Listener.Addr())
 
 }

--- a/fakes_test.go
+++ b/fakes_test.go
@@ -11,14 +11,14 @@ import (
 func TestFakes(t *testing.T) {
 
 	t.Run("we can run an in-memory test fake", func(t *testing.T) {
-		fakeServer := fakes.NewFakeHTTP("8080")
+		fakeServer := fakes.NewFakeHTTP()
 		fakeServer.AddEndpoint(&fakes.Endpoint{
 			Path:     "/",
 			Response: "{}",
 		})
 		fakeServer.Run(t)
 
-		request, err := http.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+		request, err := http.NewRequest(http.MethodGet, fakeServer.BaseURL, nil)
 		assert.Nil(t, err)
 
 		response, err := http.DefaultClient.Do(request)
@@ -28,13 +28,13 @@ func TestFakes(t *testing.T) {
 	})
 
 	t.Run("test the new BaseURL field on the fakeServer struct", func(t *testing.T) {
-		fakeServer := fakes.NewFakeHTTP("8080")
+		fakeServer := fakes.NewFakeHTTP()
 		fakeServer.AddEndpoint(&fakes.Endpoint{
 			Path:     "/",
 			Response: "{}",
 		})
 		fakeServer.Run(t)
-
+		t.Logf("BaseURL: %s\n", fakeServer.BaseURL)
 		request, err := http.NewRequest(http.MethodGet, fakeServer.BaseURL, nil)
 		assert.Nil(t, err)
 

--- a/fakes_test.go
+++ b/fakes_test.go
@@ -25,6 +25,22 @@ func TestFakes(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
 
+	t.Run("test the new BaseURL field on the fakeServer struct", func(t *testing.T) {
+		fakeServer := fakes.NewFakeHTTP("8080")
+		fakeServer.AddEndpoint(&fakes.Endpoint{
+			Path:     "/",
+			Response: "{}",
+		})
+		fakeServer.Run(t)
+
+		request, err := http.NewRequest(http.MethodGet, fakeServer.BaseURL, nil)
+		assert.Nil(t, err)
+
+		response, err := http.DefaultClient.Do(request)
+		assert.Nil(t, err)
+
+		assert.Equal(t, http.StatusOK, response.StatusCode)
 	})
 }


### PR DESCRIPTION
Whilst working through stuff on another project, this struck me as a nice bit of developer experience to expose this so that we can reference it like:

```go
fakeServer.BaseURL
```

As opposed to doing some string concatenation and trying to figure out what the actual path should be.