### PR TITLE
Adds run-on syntax that provides a better developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,22 @@ downstreamAPI.Endpoint(&fakes.Endpoint{
 > Note: if you define an endpoint for your test, it will need to be hit at least once in order for the tests to pass. This is
 to help prevent unused endpoints from being defined within your tests.
 
+## Stringing Your Setup Together
+
+The `fakes` library includes the ability to string your setup together in
+one succinct assertion. Let's take a look at an example of setting this up 
+with 2 distinct endpoints:
+
+```go
+fakeServer := fakes.New().
+    Endpoint(&fakes.Endpoint{
+        Path:     "/",
+        Response: "{}",
+    }).
+    Endpoint(&fakes.Endpoint{
+        Path:     "/hello",
+        Response: `{"message":"hello"}`,
+    }).Run(t)
+```
+
+A nice bit of syntactic sugar for those that prefer this approach!

--- a/fakes.go
+++ b/fakes.go
@@ -85,7 +85,7 @@ func (e *Endpoint) recordCall() {
 // 'application/json'.
 // Whenever said endpoint is called, we ensure that we record the call
 // and increment the `calls` field.
-func (f *FakeService) Endpoint(e *Endpoint) {
+func (f *FakeService) Endpoint(e *Endpoint) *FakeService {
 	f.Endpoints = append(f.Endpoints, e)
 
 	// if the user of the lib doesn't explicitly set the
@@ -140,6 +140,8 @@ func (f *FakeService) Endpoint(e *Endpoint) {
 			Data:        []byte(e.Response),
 		})
 	})
+
+	return f
 }
 
 // TidyUp - this method ranges over all of the endpoints defined
@@ -158,21 +160,22 @@ func (f *FakeService) TidyUp(t *testing.T) {
 // which then replaces the testserver listener. This was due to communication
 // issues between docker containers originally, however, this argument may
 // no longer hold water.
-func (f *FakeService) Run(t *testing.T) {
+func (f *FakeService) Run(t *testing.T) *FakeService {
 	t.Log("Fake Service Starting up...")
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", f.Port))
 	if err != nil {
 		t.Errorf("Failed to listen: %s", err.Error())
-		return
+		return f
 	}
 	err = f.testserver.Listener.Close()
 	if err != nil {
 		t.Errorf("Failed to close the testserver listener: %s", err.Error())
-		return
+		return f
 	}
 	f.testserver.Listener = l
 	f.testserver.Start()
 	f.BaseURL = f.testserver.URL
 	t.Logf("Fake Service Successfully Started: %s", f.testserver.Listener.Addr())
 
+	return f
 }

--- a/fakes_test.go
+++ b/fakes_test.go
@@ -198,4 +198,46 @@ func TestFakes(t *testing.T) {
 		//nolint
 		defer response.Body.Close()
 	})
+
+	t.Run("test run on syntax", func(t *testing.T) {
+		fakeServer := fakes.New().
+			Endpoint(&fakes.Endpoint{
+				Path:     "/",
+				Response: "{}",
+			}).
+			Endpoint(&fakes.Endpoint{
+				Path:     "/hello",
+				Response: `{"message":"hello"}`,
+			}).Run(t)
+		defer fakeServer.TidyUp(t)
+
+		request, err := http.NewRequest(
+			http.MethodGet,
+			fakeServer.BaseURL,
+			nil,
+		)
+		assert.Nil(t, err)
+
+		response, err := http.DefaultClient.Do(request)
+		assert.Nil(t, err)
+		//nolint
+		defer response.Body.Close()
+
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+
+		request, err = http.NewRequest(
+			http.MethodGet,
+			fakeServer.BaseURL+"/hello",
+			nil,
+		)
+		assert.Nil(t, err)
+
+		response, err = http.DefaultClient.Do(request)
+		assert.Nil(t, err)
+		//nolint
+		defer response.Body.Close()
+
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	})
 }


### PR DESCRIPTION
## Stringing Your Setup Together

The `fakes` library includes the ability to string your setup together in
one succinct assertion. Let's take a look at an example of setting this up 
with 2 distinct endpoints:

```go
fakeServer := fakes.New().
    Endpoint(&fakes.Endpoint{
        Path:     "/",
        Response: "{}",
    }).
    Endpoint(&fakes.Endpoint{
        Path:     "/hello",
        Response: `{"message":"hello"}`,
    }).Run(t)
```

A nice bit of syntactic sugar for those that prefer this approach!